### PR TITLE
replacing \/ tuples to \\/ as shopify has made the second a default

### DIFF
--- a/lib/express-shopify-webhooks.js
+++ b/lib/express-shopify-webhooks.js
@@ -94,12 +94,12 @@ shopifyWebhooks.validateSignature = function(req, res, buffer, encoding) {
     var headerHmac = req['headers']['x-shopify-hmac-sha256'];
     if (headerHmac) {
         var hmac = crypto.createHmac('sha256', shopifyWebhooks.options.shopify_shared_secret);
-        hmac.update(buffer);
         // Shopify seems to have changed the forward slash escaping
         // from a single back slash to double back slashes
         // in this case we want to replace all \/ tuples
         // to \\/
-        var calculatedHmac = hmac.digest('base64').replace(/\//g, '\\/');
+        hmac.update(buffer.replace(/\//g, '\\/'););
+        var calculatedHmac = hmac.digest('base64');
         if (calculatedHmac === headerHmac)
             req.validShopifyWebhook = true;
     }

--- a/lib/express-shopify-webhooks.js
+++ b/lib/express-shopify-webhooks.js
@@ -95,7 +95,11 @@ shopifyWebhooks.validateSignature = function(req, res, buffer, encoding) {
     if (headerHmac) {
         var hmac = crypto.createHmac('sha256', shopifyWebhooks.options.shopify_shared_secret);
         hmac.update(buffer);
-        var calculatedHmac = hmac.digest('base64');
+        // Shopify seems to have changed the forward slash escaping
+        // from a single back slash to double back slashes
+        // in this case we want to replace all \/ tuples
+        // to \\/
+        var calculatedHmac = hmac.digest('base64').replace(/\//g, '\\/');
         if (calculatedHmac === headerHmac)
             req.validShopifyWebhook = true;
     }


### PR DESCRIPTION
Hi!
We've been using this package for a while, but few months ago we examined that webhooks our application should work with are heading back to Shopify with 403 error.
As soon as we checked the logs we realised that calculated hmac and hmac in header are not the same. After some manipulations we found out the roots of this issue and managed to fix it.
It seems like Shopify has changed the forward slash escaping pattern from \\/ to \\\\/ so we has made changes according to the new behavior and it works just fine.