### PR TITLE
remove ";" in express-shopify-webhooks.js

### DIFF
--- a/lib/express-shopify-webhooks.js
+++ b/lib/express-shopify-webhooks.js
@@ -98,7 +98,7 @@ shopifyWebhooks.validateSignature = function(req, res, buffer, encoding) {
         // from a single back slash to double back slashes
         // in this case we want to replace all \/ tuples
         // to \\/
-        hmac.update(buffer.replace(/\//g, '\\/'););
+        hmac.update(buffer.replace(/\//g, '\\/'));
         var calculatedHmac = hmac.digest('base64');
         if (calculatedHmac === headerHmac)
             req.validShopifyWebhook = true;


### PR DESCRIPTION
line 101 - remove ";"
hmac.update(buffer.replace(/\//g, '\\/');); => hmac.update(buffer.replace(/\//g, '\\/'));